### PR TITLE
fix: the whole page scrolls instead of only the right part when overflowing

### DIFF
--- a/src/lib/components/cargoes/index.svelte
+++ b/src/lib/components/cargoes/index.svelte
@@ -333,6 +333,13 @@
 </div>
 
 <style>
+    .right {
+        border: 1px solid var(--mdc-theme-on-surface, #fff);
+        height: calc(100vh - 180px);
+        padding: 12px;
+        overflow: auto;
+    }
+
     .right :global(.mdc-text-field) {
         margin-top: 12px;
         width: 100%;

--- a/src/lib/components/common/listing.svelte
+++ b/src/lib/components/common/listing.svelte
@@ -28,7 +28,7 @@
         border-style: solid;
         border-width: 1px;
 
-        height: calc(100vh - 290px);
+        height: calc(100vh - 230px);
         overflow: auto;
     }
 </style>

--- a/src/lib/components/industries/cargoSecondary.svelte
+++ b/src/lib/components/industries/cargoSecondary.svelte
@@ -55,7 +55,7 @@
     );
 </script>
 
-<div style="width: 960px; overflow: auto; padding-bottom: 12px;">
+<div style="width: 924px; overflow: auto; padding-bottom: 12px;">
     <div style="width: {265 * (2 + secondary.acceptance.length)}px;">
         <span style="width: 262px; display: inline-block" />
         {#each secondary.acceptance as acceptance}

--- a/src/lib/components/industries/index.svelte
+++ b/src/lib/components/industries/index.svelte
@@ -135,6 +135,13 @@
 </div>
 
 <style>
+    .right {
+        border: 1px solid var(--mdc-theme-on-surface, #fff);
+        height: calc(100vh - 180px);
+        padding: 12px;
+        overflow: auto;
+    }
+
     .right :global(.mdc-text-field) {
         margin-top: 12px;
         width: 100%;


### PR DESCRIPTION
The whole page scrolled, which meant you couldn't get to the listing
anymore. With this fix, you can scroll the right side without the
listing scrolling.